### PR TITLE
Make font selection dialog resizable and add horizontal scrollbar

### DIFF
--- a/Epub_Tool_TKUI.py
+++ b/Epub_Tool_TKUI.py
@@ -42,7 +42,7 @@ except ImportError:
         return 0
 
     def list_epub_font_encrypt_targets(epub_path):
-        return {"font_families": [], "xhtml_files": []}
+        return {"font_families": []}
 
     encrypt_run = decrypt_run = reformat_run = run_epub_font_encrypt = (
         run_epub_img_transfer
@@ -67,8 +67,12 @@ class FontEncryptSelectionDialog(simpledialog.Dialog):
         listbox.select_set(0, tk.END)
 
     def body(self, master):
+        self.resizable(True, True)
+        self.geometry("900x520")
+        self.minsize(700, 420)
+
         master.grid_columnconfigure(0, weight=1)
-        master.grid_columnconfigure(1, weight=1)
+        master.grid_columnconfigure(1, weight=0)
         master.grid_rowconfigure(1, weight=1)
 
         ttk.Label(
@@ -90,15 +94,22 @@ class FontEncryptSelectionDialog(simpledialog.Dialog):
             font_frame, orient=tk.VERTICAL, command=self.font_listbox.yview
         )
         font_scroll.grid(row=0, column=1, sticky="ns")
-        self.font_listbox.config(yscrollcommand=font_scroll.set)
+        font_scroll_x = ttk.Scrollbar(
+            font_frame, orient=tk.HORIZONTAL, command=self.font_listbox.xview
+        )
+        font_scroll_x.grid(row=1, column=0, sticky="ew")
+        self.font_listbox.config(
+            yscrollcommand=font_scroll.set,
+            xscrollcommand=font_scroll_x.set,
+        )
 
         for item in self.font_options:
-            self.font_listbox.insert(tk.END, item)
+            self.font_listbox.insert(tk.END, item["label"])
         if self.font_options:
             self.font_listbox.select_set(0, tk.END)
 
         font_btns = ttk.Frame(font_frame)
-        font_btns.grid(row=1, column=0, columnspan=2, sticky="ew", pady=(8, 0))
+        font_btns.grid(row=2, column=0, columnspan=2, sticky="ew", pady=(8, 0))
         ttk.Button(
             font_btns,
             text="全选",
@@ -125,7 +136,7 @@ class FontEncryptSelectionDialog(simpledialog.Dialog):
 
     def apply(self):
         self.result = {
-            "target_font_families": [
+            "selected_font_targets": [
                 self.font_options[index] for index in self.font_listbox.curselection()
             ]
         }
@@ -508,21 +519,45 @@ class ModernEpubTool(BaseClass):
         self.path_var.set("默认: 源文件同级目录")
 
     def _ask_font_encrypt_options(self, file_data):
-        font_families = set()
+        font_option_map = {}
         for one_file in file_data:
             try:
                 result = list_epub_font_encrypt_targets(one_file)
-                font_families.update(result.get("font_families", []))
+                epub_path = os.path.normpath(one_file)
+                epub_name = os.path.basename(epub_path)
+                for font_family in result.get("font_families", []):
+                    key = (epub_path.lower(), (font_family or "").lower())
+                    if key in font_option_map:
+                        continue
+                    font_option_map[key] = {
+                        "label": f"[{epub_name}] {font_family}",
+                        "font_family": font_family,
+                        "epub_path": epub_path,
+                    }
             except Exception:
                 continue
 
         dialog = FontEncryptSelectionDialog(
             self,
-            sorted(font_families, key=str.lower),
+            sorted(font_option_map.values(), key=lambda item: item["label"].lower()),
         )
         if dialog.result is None:
             return None
-        return dialog.result
+
+        target_font_families_by_file = {}
+        for item in dialog.result.get("selected_font_targets", []):
+            epub_path = os.path.normpath(item.get("epub_path", ""))
+            font_family = (item.get("font_family") or "").strip()
+            if not epub_path or not font_family:
+                continue
+            target_font_families_by_file.setdefault(epub_path, set()).add(font_family)
+
+        return {
+            "target_font_families_by_file": {
+                epub_path: sorted(fonts, key=str.lower)
+                for epub_path, fonts in target_font_families_by_file.items()
+            }
+        }
 
     def start_task(self, func, task_name):
         items = self.file_tree.get_children()
@@ -557,7 +592,17 @@ class ModernEpubTool(BaseClass):
             real_out_dir = out_dir if out_dir else os.path.dirname(f_path)
 
             try:
-                if task_kwargs:
+                if func == run_epub_font_encrypt and task_kwargs:
+                    target_map = task_kwargs.get("target_font_families_by_file", {})
+                    one_file_targets = target_map.get(os.path.normpath(f_path), [])
+                    if not one_file_targets:
+                        tag, status = ("skip", "跳过")
+                        msg = "未为该EPUB选择目标字体，已跳过"
+                        self.msg_queue.put((status, f_name, msg, real_out_dir, tag))
+                        self.msg_queue.put("step")
+                        continue
+                    ret = func(f_path, out_dir, target_font_families=one_file_targets)
+                elif task_kwargs:
                     ret = func(f_path, out_dir, **task_kwargs)
                 else:
                     ret = func(f_path, out_dir)


### PR DESCRIPTION
### Motivation
- Long `[{epub}] 字体` labels used to distinguish source EPUBs are being truncated and the selection dialog did not resize, making it hard to see which font belongs to which EPUB. 

### Description
- Make the font selection dialog resizable by calling `self.resizable(True, True)`, set a larger default geometry and a reasonable `minsize`, and adjust master grid weights to allow layout scaling. 
- Add a horizontal scrollbar (`font_scroll_x`) and wire it to the `Listbox` via `xscrollcommand` so long labels can be scrolled horizontally, and move the button row below the new scrollbar. 
- Ensure the listbox inserts `item["label"]` for each option so the new `[{epub}] <font>` labels are shown correctly.

### Testing
- Compiled the modified module with `python -m py_compile Epub_Tool_TKUI.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cb19c02b4832f9c54dc474eb00249)