### PR TITLE
fix: Release body 换行丢失问题

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,38 +16,9 @@ on:
         required: false
         default: ""
       body:
-        description: "Release body text"
-        required: true
-        default: |
-          ## 安装
-
-          ### macOS
-
-          ```bash
-          brew tap cnwxi/tap
-          brew install --cask epub-tool-newui
-          ```
-
-          或下载下方 `macos_arm64.dmg`，双击挂载后将应用拖入 `/Applications`。
-
-          ### Linux
-
-          下载下方 `linux_x64.AppImage`，添加执行权限后运行：
-
-          ```bash
-          chmod +x Epub.Tool.NewUI_*.AppImage
-          ./Epub.Tool.NewUI_*.AppImage
-          ```
-
-          也可使用 `.deb` 或 `.rpm` 包安装。
-
-          ### Windows
-
-          下载下方 `windows_x64_setup.exe` 或 `.msi`，双击安装。
-
-          ---
-
-          📖 [README](https://github.com/cnwxi/epub_tool#readme) · 📝 [更新日志](https://github.com/cnwxi/epub_tool/blob/main/CHANGELOG.md)
+        description: "Release body text（留空使用默认安装指引）"
+        required: false
+        default: ""
 
 jobs:
   prepare:
@@ -332,12 +303,54 @@ jobs:
           path: release-assets
           merge-multiple: true
 
+      - name: Prepare release body
+        shell: bash
+        env:
+          RELEASE_BODY: ${{ inputs.body }}
+        run: |
+          set -euo pipefail
+          cat > release-body.md <<'MARKDOWN'
+          ## 安装
+
+          ### macOS
+
+          ```bash
+          brew tap cnwxi/tap
+          brew install --cask epub-tool-newui
+          ```
+
+          或下载下方 `macos_arm64.dmg`，双击挂载后将应用拖入 `/Applications`。
+
+          ### Linux
+
+          下载下方 `linux_x64.AppImage`，添加执行权限后运行：
+
+          ```bash
+          chmod +x Epub.Tool.NewUI_*.AppImage
+          ./Epub.Tool.NewUI_*.AppImage
+          ```
+
+          也可使用 `.deb` 或 `.rpm` 包安装。
+
+          ### Windows
+
+          下载下方 `windows_x64_setup.exe` 或 `.msi`，双击安装。
+
+          ---
+
+          📖 [README](https://github.com/cnwxi/epub_tool#readme) · 📝 [更新日志](https://github.com/cnwxi/epub_tool/blob/main/CHANGELOG.md)
+          MARKDOWN
+
+          if [ -n "$RELEASE_BODY" ]; then
+            printf '%s\n' "$RELEASE_BODY" > release-body.md
+          fi
+
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.prepare.outputs.release_version }}
           name: ${{ needs.prepare.outputs.release_version }}
-          body: ${{ inputs.body }}
+          body_path: release-body.md
           files: release-assets/*
           fail_on_unmatched_files: true
           overwrite_files: true


### PR DESCRIPTION
## 问题

`build.yml` workflow_dispatch 的 `body` 输入使用 YAML `|` literal block 作为默认值。当通过 `${{ inputs.body }}` 传递给 `softprops/action-gh-release` 的 `body` 参数时，多行字符串中的换行符在 GitHub Actions 表达式求值过程中丢失，导致 Release body 渲染为一段连续文本。

## 修复

- `body` 输入改为 optional（`required: false`, `default: ""`）
- 默认 Release body 改用 bash heredoc 写入文件，彻底绕开 YAML 多行字符串传递问题
- 发布步骤改用 `body_path` 读取文件，而非直接将多行字符串传入 action input
- 用户触发 workflow 时仍可填写自定义 body，不为空时覆盖默认文件