### PR TITLE
fix: Homebrew Tap 更新集成到 build.yml 解决级联触发失效

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -354,3 +354,87 @@ jobs:
           files: release-assets/*
           fail_on_unmatched_files: true
           overwrite_files: true
+
+  update_homebrew_tap:
+    name: Update Homebrew Tap
+    if: inputs.release
+    runs-on: ubuntu-22.04
+    needs:
+      - prepare
+      - publish_release
+    permissions:
+      contents: read
+    steps:
+      - name: Find macOS dmg asset
+        id: asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ needs.prepare.outputs.release_version }}"
+          dmg_url=$(gh release view "$tag" --repo "${{ github.repository }}" --json assets \
+            --jq '.assets[] | select(.name | test("macos.*\\.dmg$")) | .url')
+
+          if [ -z "$dmg_url" ]; then
+            echo "未找到 macOS dmg 资产，跳过 Homebrew Tap 更新"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "url=$dmg_url" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Compute sha256
+        if: steps.asset.outputs.skip != 'true'
+        id: sha
+        shell: bash
+        run: |
+          set -euo pipefail
+          url="${{ steps.asset.outputs.url }}"
+          echo "正在下载: $url"
+          curl -fsSL "$url" -o /tmp/epub-tool.dmg
+          sha=$(shasum -a 256 /tmp/epub-tool.dmg | awk '{print $1}')
+          echo "sha256=$sha"
+          echo "sha256=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout tap repo
+        if: steps.asset.outputs.skip != 'true'
+        uses: actions/checkout@v5
+        with:
+          repository: cnwxi/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap-repo
+
+      - name: Update cask formula
+        if: steps.asset.outputs.skip != 'true'
+        shell: bash
+        run: |
+          VERSION="${{ needs.prepare.outputs.asset_version }}"
+          SHA="${{ steps.sha.outputs.sha256 }}"
+          FORMULA="tap-repo/Casks/epub-tool-newui.rb"
+
+          echo "更新公式:"
+          echo "  version: $VERSION"
+          echo "  sha256:  $SHA"
+
+          sed -i "s/version \".*\"/version \"$VERSION\"/" "$FORMULA"
+          sed -i "s/sha256 \".*\"/sha256 \"$SHA\"/" "$FORMULA"
+
+          echo "--- 更新后的公式 ---"
+          cat "$FORMULA"
+
+      - name: Commit and push
+        if: steps.asset.outputs.skip != 'true'
+        shell: bash
+        run: |
+          cd tap-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/epub-tool-newui.rb
+          if git diff --staged --quiet; then
+            echo "公式无变化，跳过提交"
+            exit 0
+          fi
+          git commit -m "Update epub-tool-newui to v${{ needs.prepare.outputs.asset_version }}"
+          git push origin main

--- a/.github/workflows/homebrew-update.yml
+++ b/.github/workflows/homebrew-update.yml
@@ -1,8 +1,8 @@
 name: Update Homebrew Tap
 
+# 注意：自动更新已集成到 build.yml 的 update_homebrew_tap job 中。
+# 此 workflow 仅作为手动 fallback，用于修复或重试更新。
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## 问题

`homebrew-update.yml` 监听 `release.published` 事件，但 `build.yml` 使用 `GITHUB_TOKEN` 创建 Release 时，GitHub Actions 出于安全考虑不会级联触发其他 workflow。导致每次发版后 tap 公式从未自动更新。

## 修复

- 将 tap 更新逻辑作为 `build.yml` 的新 job `update_homebrew_tap`，在 `publish_release` 后直接执行
- `homebrew-update.yml` 保留手动 `workflow_dispatch` 触发作为 fallback，移除无效的 `release.published` 触发
- 新 job 复用 `prepare` 的 `release_version`，无需额外解析版本号

## 执行流程

```
build job → publish_release job → update_homebrew_tap job
                                       ↓
                          下载 macOS dmg → sha256
                          → 更新 tap 公式 → 推送
```