### PR TITLE
fix: git push 使用 HOMEBREW_TAP_TOKEN 认证

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -427,10 +427,13 @@ jobs:
       - name: Commit and push
         if: steps.asset.outputs.skip != 'true'
         shell: bash
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           cd tap-repo
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${TAP_TOKEN}@github.com/cnwxi/homebrew-tap.git"
           git add Casks/epub-tool-newui.rb
           if git diff --staged --quiet; then
             echo "公式无变化，跳过提交"

--- a/.github/workflows/homebrew-update.yml
+++ b/.github/workflows/homebrew-update.yml
@@ -98,10 +98,13 @@ jobs:
       - name: Commit and push
         if: steps.asset.outputs.skip != 'true'
         shell: bash
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           cd tap-repo
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${TAP_TOKEN}@github.com/cnwxi/homebrew-tap.git"
           git add Casks/epub-tool-newui.rb
           if git diff --staged --quiet; then
             echo "公式无变化，跳过提交"


### PR DESCRIPTION
## 问题

`git push` 到 `cnwxi/homebrew-tap` 时报 403，因为 push 使用的是默认身份而非 token。

## 修复

在 push 前通过 `git remote set-url` 将 token 注入到 remote URL。