### PR TITLE
chore: 移除 homebrew-update.yml 死代码

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -427,10 +427,13 @@ jobs:
       - name: Commit and push
         if: steps.asset.outputs.skip != 'true'
         shell: bash
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           cd tap-repo
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${TAP_TOKEN}@github.com/cnwxi/homebrew-tap.git"
           git add Casks/epub-tool-newui.rb
           if git diff --staged --quiet; then
             echo "公式无变化，跳过提交"

--- a/.github/workflows/homebrew-update.yml
+++ b/.github/workflows/homebrew-update.yml
@@ -23,12 +23,7 @@ jobs:
         id: version
         shell: bash
         run: |
-          # 支持 workflow_dispatch 手动触发和 release 自动触发
-          if [ -n "${{ inputs.tag }}" ]; then
-            tag="${{ inputs.tag }}"
-          else
-            tag="${{ github.event.release.tag_name }}"
-          fi
+          tag="${{ inputs.tag }}"
           version="${tag#v}"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/homebrew-update.yml
+++ b/.github/workflows/homebrew-update.yml
@@ -6,9 +6,8 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag (如 v26.4.24)，留空则用最新 release"
-        required: false
-        default: ""
+        description: "Release tag（必填，如 v26.5.7）"
+        required: true
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/homebrew-update.yml
+++ b/.github/workflows/homebrew-update.yml
@@ -98,10 +98,13 @@ jobs:
       - name: Commit and push
         if: steps.asset.outputs.skip != 'true'
         shell: bash
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           cd tap-repo
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${TAP_TOKEN}@github.com/cnwxi/homebrew-tap.git"
           git add Casks/epub-tool-newui.rb
           if git diff --staged --quiet; then
             echo "公式无变化，跳过提交"


### PR DESCRIPTION
移除 Resolve version 中不再需要的 release 事件分支。tag 已改为必填，release.published 触发已移除。